### PR TITLE
fix: Using $RANDOM causes race conditions #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ See [`docs/timing.md`](./docs/timing.md).
 ## Contributors
 
 - [Zack Sargent](https://github.com/zsarge)
+- [Eliezer Nsengi](https://github.com/iAmNsengi)
 - ... and more :eyes:

--- a/services/webshell/webshell-1/start-shell.sh
+++ b/services/webshell/webshell-1/start-shell.sh
@@ -5,7 +5,7 @@ set -e
 # This script is loaded by gotty, and is in charge of starting a jailed and virtualized console.
 # This script is loaded by "Dockerfile"
 
-CONTAINER_NAME="challenge-shell-$RANDOM"
+CONTAINER_NAME="challenge-shell-$(uuidgen)"
 CONTAINER_TAG="webshell"
 TIMEOUT="300" # 300 seconds = 5 minutes
 

--- a/services/webshell/webshell-2/start-shell.sh
+++ b/services/webshell/webshell-2/start-shell.sh
@@ -5,7 +5,7 @@ set -e
 # This script is loaded by gotty, and is in charge of starting a jailed and virtualized console.
 # This script is loaded by "Dockerfile"
 
-CONTAINER_NAME="challenge-shell-$RANDOM"
+CONTAINER_NAME="challenge-shell-$(uuidgen)"
 CONTAINER_TAG="webshell"
 TIMEOUT="300" # 300 seconds = 5 minutes
 

--- a/services/webshell/webshell-3/start-shell.sh
+++ b/services/webshell/webshell-3/start-shell.sh
@@ -5,7 +5,7 @@ set -e
 # This script is loaded by gotty, and is in charge of starting a jailed and virtualized console.
 # This script is loaded by "Dockerfile"
 
-CONTAINER_NAME="challenge-shell-$RANDOM"
+CONTAINER_NAME="challenge-shell-$(uuidgen)"
 CONTAINER_TAG="webshell"
 TIMEOUT="300" # 300 seconds = 5 minutes
 

--- a/services/webshell/webshell-4/start-shell.sh
+++ b/services/webshell/webshell-4/start-shell.sh
@@ -5,7 +5,7 @@ set -e
 # This script is loaded by gotty, and is in charge of starting a jailed and virtualized console.
 # This script is loaded by "Dockerfile"
 
-CONTAINER_NAME="challenge-shell-$RANDOM"
+CONTAINER_NAME="challenge-shell-$(uuidgen)"
 CONTAINER_TAG="webshell"
 TIMEOUT="300" # 300 seconds = 5 minutes
 

--- a/services/webshell/webshell-5/start-shell.sh
+++ b/services/webshell/webshell-5/start-shell.sh
@@ -5,7 +5,7 @@ set -e
 # This script is loaded by gotty, and is in charge of starting a jailed and virtualized console.
 # This script is loaded by "Dockerfile"
 
-CONTAINER_NAME="challenge-shell-$RANDOM"
+CONTAINER_NAME="challenge-shell-$(uuidgen)"
 CONTAINER_TAG="webshell"
 TIMEOUT="300" # 300 seconds = 5 minutes
 

--- a/services/webshell/webshell-6/start-shell.sh
+++ b/services/webshell/webshell-6/start-shell.sh
@@ -5,7 +5,7 @@ set -e
 # This script is loaded by gotty, and is in charge of starting a jailed and virtualized console.
 # This script is loaded by "Dockerfile"
 
-CONTAINER_NAME="challenge-shell-$RANDOM"
+CONTAINER_NAME="challenge-shell-$(uuidgen)"
 CONTAINER_TAG="webshell"
 TIMEOUT="300" # 300 seconds = 5 minutes
 


### PR DESCRIPTION
## 
Replaces shell **$RANDOM** with **uuidgen** in webshell challenge scripts to prevent container name collisions during concurrent access. This fixes the issue where multiple users accessing webshell challenges simultaneously could be directed to the same container due to $RANDOM's limited range.

**Testing**: Verified unique container name generation across multiple concurrent executions.

fixes #11 